### PR TITLE
Added gpu flag to detect_common_objects method

### DIFF
--- a/cvlib/object_detection.py
+++ b/cvlib/object_detection.py
@@ -55,7 +55,7 @@ def draw_bbox(img, bbox, labels, confidence, colors=None, write_conf=False):
 
     return img
     
-def detect_common_objects(image, confidence=0.5, nms_thresh=0.3, model='yolov3'):
+def detect_common_objects(image, confidence=0.5, nms_thresh=0.3, model='yolov3', gpu_enabled=False):
 
     Height, Width = image.shape[:2]
     scale = 0.00392
@@ -93,6 +93,11 @@ def detect_common_objects(image, confidence=0.5, nms_thresh=0.3, model='yolov3')
     if initialize:
         classes = populate_class_labels()
         net = cv2.dnn.readNet(weights_file_abs_path, config_file_abs_path)
+        # enables opencv dnn module to use CUDA on Nvidia card instead of cpu
+        if gpu_enabled == True:
+            net.setPreferableBackend(cv2.dnn.DNN_BACKEND_CUDA)
+            net.setPreferableTarget(cv2.dnn.DNN_TARGET_CUDA)
+
         initialize = False
 
     net.setInput(blob)


### PR DESCRIPTION
I use your library in my People Detector repo. I've recently recompiled opencv with CUDA funcionality and the results are amazing. 

The pull request would add the option for users of your library to use GPU instead of CPU. 

I'm currently writing up a tutorial on how a user can set all this up on their system:
 - set up Cuda and CuDNN on their system
- compile opencv from source etc....