### PR TITLE
fix object_detection.py

### DIFF
--- a/cvlib/object_detection.py
+++ b/cvlib/object_detection.py
@@ -26,7 +26,7 @@ def get_output_layers(net):
     
     layer_names = net.getLayerNames()
     
-    output_layers = [layer_names[i[0] - 1] for i in net.getUnconnectedOutLayers()]
+    output_layers = [layer_names[i- 1] for i in net.getUnconnectedOutLayers()]
 
     return output_layers
 
@@ -162,7 +162,7 @@ def detect_common_objects(image, confidence=0.5, nms_thresh=0.3, model='yolov4',
     conf = []
 
     for i in indices:
-        i = i[0]
+        i = indices[0]
         box = boxes[i]
         x = box[0]
         y = box[1]
@@ -194,7 +194,7 @@ class YOLO:
     
         layer_names = self.net.getLayerNames()
     
-        self.output_layers = [layer_names[i[0] - 1] for i in self.net.getUnconnectedOutLayers()]
+        self.output_layers = [layer_names[i - 1] for i in self.net.getUnconnectedOutLayers()]
 
 
     def detect_objects(self, image, confidence=0.5, nms_thresh=0.3,


### PR DESCRIPTION
Fix this issue: 
Traceback (most recent call last):#################################################################################### |
  File "detector_mine.py", line 35, in <module>
    bbox, label, conf = cv.detect_common_objects(rect_img, confidence=0.75, enable_gpu=True')
  File "/home/user/.local/lib/python3.8/site-packages/cvlib/object_detection.py", line 135, in detect_common_objects
    outs = net.forward(get_output_layers(net))
  File "/home/user/.local/lib/python3.8/site-packages/cvlib/object_detection.py", line 29, in get_output_layers
    output_layers = [layer_names[i[0] - 1] for i in net.getUnconnectedOutLayers()]
  File "/home/user/.local/lib/python3.8/site-packages/cvlib/object_detection.py", line 29, in <listcomp>
    output_layers = [layer_names[i[0] - 1] for i in net.getUnconnectedOutLayers()]
IndexError: invalid index to scalar variable.